### PR TITLE
Fixed issue with DEBUG being always TRUE when on OPENSHIFT.

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -1,6 +1,7 @@
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import socket
+import ast
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -16,7 +17,7 @@ else:
 # SECURITY WARNING: don't run with debug turned on in production!
 # adjust to turn off when on Openshift, but allow an environment variable to override on PAAS
 DEBUG = not ON_PAAS
-DEBUG = DEBUG or 'DEBUG' in os.environ
+DEBUG = DEBUG or ast.literal_eval(os.environ.get('DEBUG', 'False'))
 if ON_PAAS and DEBUG:
     print("*** Warning - Debug mode is on ***")
 


### PR DESCRIPTION
I have changed the logic for setting the DEBUG variable in settings. I had problem with running my application on Openshift, where application would run for half a day, then fail with 503 Service Unavailable (check issue https://github.com/jfmatth/openshift-django17/issues/16). It turned out that the reason for that was [memory limit violation on Openshift](https://help.openshift.com/hc/en-us/articles/202399600-How-to-check-for-memory-limit-violations) due to DEBUG being set to True. Now [readme clearly specifies](https://github.com/jfmatth/openshift-django17#debugging-mode-and-openshift), that to turn the debugging mode ON on OPENSHIFT, we must run the following command:

```
rhc env set DEBUG=True
```

The problem is, that the current logic checks only if key 'DEBUG' **exists** inside a mapping object of environment variables. I propose a solution which first checks if key 'DEBUG' exists. If it does not exists, by default it returns 'False' value. If it exists, it returns 'True' or 'False' values according to currently set value with command specified above. This is then in turn wrapped with ast.literal_eval, to return the boolean value according to passed string.
